### PR TITLE
rust: changed mailpw parameter to mail_pw

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -5,7 +5,7 @@
 run the bot:
 
 ```
-addr=$yourEmail mailpw=$yourPassword cargo run
+addr=$yourEmail mail_pw=$yourPassword cargo run
 ```
 
 ### Documentation

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -91,12 +91,12 @@ async fn main() {
         } else {
             panic!("no addr ENV var specified");
         }
-        if let Some(pw) = vars().find(|key| key.0 == "mailpw") {
+        if let Some(pw) = vars().find(|key| key.0 == "mail_pw") {
             ctx.set_config(config::Config::MailPw, Some(&pw.1))
                 .await
                 .unwrap();
         } else {
-            panic!("no mailpw ENV var specified");
+            panic!("no mail_pw ENV var specified");
         }
         ctx.set_config(config::Config::Bot, Some("1"))
             .await


### PR DESCRIPTION
I also have a local commit for C, but it doesn't compile (see #20), it still uses the deaddrop concept and looks quite outdated. But my C is not good enough to fix it I think. Should I still push that one commit?