### PR TITLE
fix broken simplebot links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ An echo bot in multiple languages to get you started.
 
 ### With abstraction layer / bot framework:
 
-| Language                                        | core version |
-| ----------------------------------------------- | ------------ |
-| [bot-base (node.js)](./nodejs_bot_base)         | `1.27.0`     |
-| [deltabot (python)](./python_deltabot_plugin)   | `?`          |
-| [simplebot (python)](./python_simplebot_plugin) | `?`          |
+| Language                                        | core version               |
+| ----------------------------------------------- | ------------               |
+| [bot-base (node.js)](./nodejs_bot_base)         | `1.27.0`                   |
+| [deltabot (python)](./python_deltabot_plugin)   | `?`                        |
+| [simplebot (python)](./python_simplebot_plugin) | `1.93.0 (simplebot 3.3.0)` |
 
 The bot just echos your text messages when you send them to it as DM.
 

--- a/python_simplebot_plugin/README.MD
+++ b/python_simplebot_plugin/README.MD
@@ -2,7 +2,7 @@
 
 This example is about creating a plugin for [simplebot](https://github.com/simplebot-org/simplebot),
 a pluggable deltachat bot,
-which is a fork of [deltabot](https://github.com/deltachat-bot/deltabot) and has a [vast ecosystem of plugins](https://github.com/simplebot-org) already availible and used in production.
+which is a fork of [deltabot](https://github.com/deltachat-bot/deltabot) and has a [vast ecosystem of plugins](https://pypi.org/search/?q=simplebot&o=&c=Environment+%3A%3A+Plugins) already availible and used in production.
 
 > There are 2 alternative options available:
 >
@@ -22,12 +22,9 @@ virtualenv .venv
 source .venv/bin/activate
 pip3 install -U pip wheel
 
-# install deltachat
-pip3 install --pre -U -i https://m.devpi.net/dc/master deltachat # if it doesn't work, see https://github.com/deltachat/deltachat-core-rust/tree/master/python for instructions on how to install it from source)
-
 # Install simplebot
-pip3 install https://github.com/simplebot-org/simplebot/archive/master.zip
-# or alternativly pip3 install simplebot
+pip3 install simplebot
+# or alternativly: pip3 install git+https://github.com/simplebot-org/simplebot/
 
 # init the bot (either set the env vars or replace them with the email credentials the bot should use)
 simplebot --account ./.simplebotdata init $ADDR "$PASSWORD"

--- a/python_simplebot_plugin/README.MD
+++ b/python_simplebot_plugin/README.MD
@@ -2,7 +2,7 @@
 
 This example is about creating a plugin for [simplebot](https://github.com/simplebot-org/simplebot),
 a pluggable deltachat bot,
-which is a fork of [deltabot](https://github.com/deltachat-bot/deltabot) and has a [vast ecosystem of plugins](https://github.com/SimpleBot-Inc/simplebot_plugins) already availible and used in production.
+which is a fork of [deltabot](https://github.com/deltachat-bot/deltabot) and has a [vast ecosystem of plugins](https://github.com/simplebot-org) already availible and used in production.
 
 > There are 2 alternative options available:
 >
@@ -26,7 +26,7 @@ pip3 install -U pip wheel
 pip3 install --pre -U -i https://m.devpi.net/dc/master deltachat # if it doesn't work, see https://github.com/deltachat/deltachat-core-rust/tree/master/python for instructions on how to install it from source)
 
 # Install simplebot
-pip3 install https://github.com/simplebot-inc/simplebot/archive/master.zip
+pip3 install https://github.com/simplebot-org/simplebot/archive/master.zip
 # or alternativly pip3 install simplebot
 
 # init the bot (either set the env vars or replace them with the email credentials the bot should use)
@@ -66,6 +66,6 @@ simplebot -a ./.simplebotdata serve
 
 ## References
 
-Also see the source of the existing plugins over at https://github.com/simplebot-org/simplebot_plugins.
+Also see the source of the existing plugins over at https://github.com/simplebot-org/.
 
 > **Tip:** instead of manually registering script by script, simplebot supports registering folders (and also python package folders), ex. `~/my_plugins` then all script you add there will be loaded when the bot starts and you can add new script or remove existing scripts without having to add/remove using these commands


### PR DESCRIPTION
are all links right now? 

should the plugin list links just go to the organization or rather to pip (https://pypi.org/search/?q=simplebot&o=&c=Environment+%3A%3A+Plugins)?

feel free to take this pr over and push to it